### PR TITLE
Move extensions to extensions.json

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -1,4 +1,4 @@
-extension = {
+{
   ".!BT": {
     "description": "BitTorrent Incomplete Download File",
     "type": "Misc"

--- a/organize.py
+++ b/organize.py
@@ -1,13 +1,15 @@
-from extension import extension;
 from commonFiles import commonFiles;
 
 import shutil;
 from os import listdir, makedirs, startfile;
 from os.path import isfile, join;
+import json
 
 from tkinter import filedialog
 from tkinter import *
 
+with open("extensions.json") as f:
+    extensions = json.load(f)
 
 def chooseFolder():
     root = Tk()
@@ -17,7 +19,7 @@ def chooseFolder():
 
 def getFileExtension(fileName):
     fileType = ('.' + fileName.split(".")[-1]).upper();
-    return extension[fileType] if fileType in extension else "Unknown";
+    return extensions[fileType] if fileType in extensions else "Unknown";
 
 def createFolder(folderName):
     try:


### PR DESCRIPTION
This pull request moves the list of extensions from `extension.py` to `extensions.json`
Also renamed the `extension` variable in `organize.py` to `extensions`